### PR TITLE
LPS-73813 don't escape ampersand export

### DIFF
--- a/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
+++ b/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/exportimport/data/handler/DDMTemplateStagedModelDataHandler.java
@@ -247,7 +247,7 @@ public class DDMTemplateStagedModelDataHandler
 					portletDataContext, template, template.getScript(),
 					portletDataContext.getBooleanParameter(
 						DDMPortletDataHandler.NAMESPACE, "referenced-content"),
-					true);
+					false);
 
 		template.setScript(script);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-26208
https://issues.liferay.com/browse/LPS-73813

We avoid [escaping ampersand](https://github.com/liferay/liferay-portal/blob/master/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java#L99-L102) when exporting DDMTemplates.

Here is the SME discussion on whether escaping ampersand is necessary here https://issues.liferay.com/browse/LPP-26254?focusedCommentId=1077178&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-1077178.