### PR TITLE
LPS-74592 Handling for nested fields in the template manager. 

### DIFF
--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/template/BaseDDMTemplateHandler.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/template/BaseDDMTemplateHandler.java
@@ -112,13 +112,13 @@ public abstract class BaseDDMTemplateHandler extends BaseTemplateHandler {
 			ddmStructureId);
 
 		List<String> fieldNames = ListUtil.fromCollection(
-				ddmStructure.getFieldNames());
+			ddmStructure.getFieldNames());
 
 		Map<String, String> nestedFields = new HashMap<>();
 
 		for (String fieldName : fieldNames) {
 			List<String> childNames = ddmStructure.getChildrenFieldNames(
-					fieldName);
+				fieldName);
 
 			for (String childName : childNames) {
 				nestedFields.put(childName, fieldName);

--- a/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/template/BaseDDMTemplateHandler.java
+++ b/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/template/BaseDDMTemplateHandler.java
@@ -24,12 +24,16 @@ import com.liferay.portal.kernel.template.BaseTemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableCodeHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
 import com.liferay.portal.kernel.templateparser.TemplateNode;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Stack;
 
 /**
  * @author Jorge Ferrer
@@ -107,7 +111,19 @@ public abstract class BaseDDMTemplateHandler extends BaseTemplateHandler {
 		DDMStructure ddmStructure = DDMStructureLocalServiceUtil.getStructure(
 			ddmStructureId);
 
-		List<String> fieldNames = ddmStructure.getRootFieldNames();
+		List<String> fieldNames = ListUtil.fromCollection(
+				ddmStructure.getFieldNames());
+
+		Map<String, String> nestedFields = new HashMap<>();
+
+		for (String fieldName : fieldNames) {
+			List<String> childNames = ddmStructure.getChildrenFieldNames(
+					fieldName);
+
+			for (String childName : childNames) {
+				nestedFields.put(childName, fieldName);
+			}
+		}
 
 		for (String fieldName : fieldNames) {
 			String label = ddmStructure.getFieldLabel(fieldName, locale);
@@ -117,6 +133,29 @@ public abstract class BaseDDMTemplateHandler extends BaseTemplateHandler {
 
 			if (Validator.isNull(dataType)) {
 				continue;
+			}
+
+			if (nestedFields.containsKey(fieldName)) {
+				String parentName = nestedFields.get(fieldName);
+				Stack<String> parentNames = new Stack<>();
+
+				parentNames.push(parentName);
+
+				while (nestedFields.containsKey(parentName)) {
+					parentName = nestedFields.get(parentName);
+
+					parentNames.push(parentName);
+				}
+
+				StringBundler sb = new StringBundler();
+
+				while (!parentNames.isEmpty()) {
+					sb.append(parentNames.pop());
+					sb.append(".");
+				}
+
+				sb.append(fieldName);
+				fieldName = sb.toString();
 			}
 
 			templateVariableGroup.addFieldVariable(

--- a/dynamic-data-mapping-type-select/src/main/resources/META-INF/resources/select.soy
+++ b/dynamic-data-mapping-type-select/src/main/resources/META-INF/resources/select.soy
@@ -66,7 +66,7 @@
 							<div class="option-selected option-selected-placeholder">{$strings.chooseAnOption}</div>
 						{/if}
 					{/if}
-					
+
 					<a class="select-arrow-down-container" href="javascript:;">
 						{if $selectCaretDoubleIcon}
 							{$selectCaretDoubleIcon}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-74592

Hi again, Sam! This is the same code as earlier moved to the subrepo so all comments I made about it over in https://github.com/SamZiemer/liferay-portal/pull/372 still hold true.

There's one additional change in select.soy. It's reverting a change (5 tabs) in a commit made on the master branch [here](https://github.com/liferay/com-liferay-dynamic-data-mapping/commit/b8ba1cf3fe6e8619c769dbfce6b061c408434043) that was causing the source formatting tests to fail. I spoke to Michael Bowerman about it, but since there seems to still be ongoing source formatting changes made in the master branch related to this same commit I'm just including it here rather than sending it as its own commit.